### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://justis.visualstudio.com/fa6b463c-819d-4235-ab25-a33f3659b1ff/086c5fd5-1393-4800-9d1b-bcd2318d186c/_apis/work/boardbadge/b50c66e4-4c14-42e2-bb93-7a770dd31250)](https://justis.visualstudio.com/fa6b463c-819d-4235-ab25-a33f3659b1ff/_boards/board/t/086c5fd5-1393-4800-9d1b-bcd2318d186c/Microsoft.RequirementCategory)
 <!-- Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
 # Vespa sample applications
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#13862](https://justis.visualstudio.com/fa6b463c-819d-4235-ab25-a33f3659b1ff/_workitems/edit/13862). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.